### PR TITLE
Fixed opening of input images port

### DIFF
--- a/include/superqComputation.h
+++ b/include/superqComputation.h
@@ -153,11 +153,8 @@ public:
     /** Object  2D blob*/
     std::deque<cv::Point> blob_points;
 
-    /** Input image*/
-    yarp::sig::ImageOf<yarp::sig::PixelRgb> *imgIn;
-
     /***********************************************************************/
-    SuperqComputation(yarp::os::Mutex &mutex_shared, int _rate, bool _filter_points, bool _filter_superq, bool _fixed_window, std::deque<yarp::sig::Vector> &_points, yarp::sig::ImageOf<yarp::sig::PixelRgb> *imgIn,
+    SuperqComputation(yarp::os::Mutex &mutex_shared, int _rate, bool _filter_points, bool _filter_superq, bool _fixed_window, std::deque<yarp::sig::Vector> &_points,
                       std::string _tag_file, double _threshold_median, const yarp::os::Property &filters_points_par, yarp::sig::Vector &_x, yarp::sig::Vector &_x_filtered,
                       const yarp::os::Property &filters_superq_par, const yarp::os::Property &optimizer_par, const std::string &_homeContextPath, bool _save_points, yarp::os::ResourceFinder *rf);
 

--- a/include/superqModule.h
+++ b/include/superqModule.h
@@ -42,129 +42,127 @@ class SuperqModule : public yarp::os::RFModule,
 {
 protected:
 
-	/** Red value for visualization**/
+    /** Red value for visualization**/
     int r;
-	/** Green value for visualization **/
-	int g;
-	/** Blue value for visualization **/
-	int b;
-	/** Count variable**/
+    /** Green value for visualization **/
+    int g;
+    /** Blue value for visualization **/
+    int b;
+    /** Count variable**/
     int count;
-	/** Computation thread rate**/
+    /** Computation thread rate**/
     int rate;
-	/** Visualization thread rate**/
-	int rate_vis;
-	/** Tag name of files for saving 3D points**/
+    /** Visualization thread rate**/
+    int rate_vis;
+    /** Tag name of files for saving 3D points**/
     std::string tag_file;
-	/** Path where code context is located **/
+    /** Path where code context is located **/
     std::string homeContextPath;
-	/** Pointcloud name file in case the module runs offline**/
+    /** Pointcloud name file in case the module runs offline**/
     yarp::os::ConstString pointCloudFileName;
-	/** Output file name saving the estimated superquadric**/
+    /** Output file name saving the estimated superquadric**/
     std::string outputFileName;
-	/** OpenCV variable for blob extraction**/
+    /** OpenCV variable for blob extraction**/
     std::vector<cv::Point> contour;
-	/** 3D points used for reconstructing the superquadric **/
+    /** 3D points used for reconstructing the superquadric **/
     std::deque<yarp::sig::Vector> points;
-	/** 3D points auxiliary used for reconstructing the superquadric **/
+    /** 3D points auxiliary used for reconstructing the superquadric **/
     std::deque<yarp::sig::Vector> points_aux;
-	/** 2D points of the segmented object **/
+    /** 2D points of the segmented object **/
     std::deque<cv::Point> blob_points;
 
     // Filters parameters
-	/** Radius for spatial density filter**/
+    /** Radius for spatial density filter**/
     double radius;
-	/** Density threshold for spatial density filter**/
+    /** Density threshold for spatial density filter**/
     int nnThreshold;
-	
+    
     int numVertices;
-	/** Median filder order**/
+    /** Median filder order**/
     int median_order;
-	/** Minimum median filder order allowed**/
+    /** Minimum median filder order allowed**/
     int min_median_order;
-	/** Maximum median filder order allowed**/
+    /** Maximum median filder order allowed**/
     int max_median_order;
-	/** New median filder order estimated**/
+    /** New median filder order estimated**/
     int new_median_order;
-	/** Boolean variable for enabling point cloud filtering**/
+    /** Boolean variable for enabling point cloud filtering**/
     bool filter_points;
-	/** Boolean variable for enabling the use of a fixed window during the median filter**/
+    /** Boolean variable for enabling the use of a fixed window during the median filter**/
     bool fixed_window;
-	/** Boolean variable for enabling superquadric filtering**/
+    /** Boolean variable for enabling superquadric filtering**/
     bool filter_superq;
-	/** String used for deciding what to plot: "points" or "superq"**/
+    /** String used for deciding what to plot: "points" or "superq"**/
     std::string what_to_plot;
-	/** Threshold for velocity estimation for median order**/
+    /** Threshold for velocity estimation for median order**/
     double threshold_median;
-	/** Minimum norm of velocity for considering the object moving**/
+    /** Minimum norm of velocity for considering the object moving**/
     double min_norm_vel;
 
     // On/off options
-	/** Boolean variable for enabling online or offline mode**/
+    /** Boolean variable for enabling online or offline mode**/
     bool mode_online;
-	/** Boolean variable for enabling visualization**/
+    /** Boolean variable for enabling visualization**/
     bool visualization_on;
-	/** Boolean variable for going to the next step of the state machine**/
+    /** Boolean variable for going to the next step of the state machine**/
     bool go_on;
-	/** Boolean variable for resetting the median filter**/
+    /** Boolean variable for resetting the median filter**/
     bool reset;
-	/** Boolean variable for enabling point cloud saving**/
+    /** Boolean variable for enabling point cloud saving**/
     bool save_points;
 
     // Optimization parameters
-	/** Tolerance of the optimization problem **/
+    /** Tolerance of the optimization problem **/
     double tol;
-	double sum;
-	/** Max cpu time allowed for solving the optimization problem**/
+    double sum;
+    /** Max cpu time allowed for solving the optimization problem**/
     double max_cpu_time;
-	/** Acceptable iter of Ipopt algorithm**/
+    /** Acceptable iter of Ipopt algorithm**/
     int acceptable_iter;
-	/** Maximum iteration allowed of Ipopt algorithm**/
-	int max_iter;
-	/** Number of 3D points used for optimization**/
+    /** Maximum iteration allowed of Ipopt algorithm**/
+    int max_iter;
+    /** Number of 3D points used for optimization**/
     int optimizer_points;
-	/** Mu strategy of the Ipopt algorithm**/
+    /** Mu strategy of the Ipopt algorithm**/
     std::string mu_strategy;
-	/** NLP scaling method of the Ipopt algorithm**/
-	std::string nlp_scaling_method;
+    /** NLP scaling method of the Ipopt algorithm**/
+    std::string nlp_scaling_method;
 
-	/** Estimated superquadric**/
+    /** Estimated superquadric**/
     yarp::sig::Vector x;
-	/** Filtered superquadric**/
+    /** Filtered superquadric**/
     yarp::sig::Vector x_filtered;
 
     // Time variables
-	/** Time required for computing superquadric**/
+    /** Time required for computing superquadric**/
     double t_superq;
-	/** Times used for computing several superquadrics**/
+    /** Times used for computing several superquadrics**/
     std::deque<double> times_superq;
-	/** Time for visualization**/
+    /** Time for visualization**/
     double t_vis;
-	/** Collections of times required for visualization**/
+    /** Collections of times required for visualization**/
     std::deque<double> times_vis;
 
-    /**Input image port **/
-    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > portImgIn;
     /** Port for streaming the computed superquadric**/
     yarp::os::BufferedPort<yarp::os::Property> portSuperq;
     /** Rpc port for interaction**/
     yarp::os::RpcServer portRpc;
 
     // Variables for visualization and gaze
-	/** Number of points used for visualization**/
+    /** Number of points used for visualization**/
     int vis_points;
-	/** Number of visualization step**/
+    /** Number of visualization step**/
     int vis_step;
-	/** Eye camera selected **/
+    /** Eye camera selected **/
     std::string eye;
     yarp::sig::Matrix R,H,K;
     yarp::sig::Vector point,point1;
     yarp::sig:: Vector point2D;
-	/** Color used for visualization**/
+    /** Color used for visualization**/
     std::deque<int> Color;
-	/** Gaze Control driver for visualization**/
+    /** Gaze Control driver for visualization**/
     yarp::dev::PolyDriver GazeCtrl;
-	/** Gaze Control interface **/
+    /** Gaze Control interface **/
     yarp::dev::IGazeControl *igaze;
 
     yarp::os::ResourceFinder *rf;
@@ -176,21 +174,18 @@ protected:
     std::string object_class;
 
     // Classes of the threads
-	/** SuperqComputation class actually computes the superquadric**/
+    /** SuperqComputation class actually computes the superquadric**/
     SuperqComputation *superqCom;
-	/** SuperqVisualization class shows the estimated superquadric**/
+    /** SuperqVisualization class shows the estimated superquadric**/
     SuperqVisualization *superqVis;
 
     // Property with all the parameters
-	/** Parameters of point cloud filter**/
+    /** Parameters of point cloud filter**/
     yarp::os::Property filter_points_par;
-	/** Parameters of superquadric filter**/
+    /** Parameters of superquadric filter**/
     yarp::os::Property filter_superq_par;
-	/** Parameters of the Ipopt optimization problem**/
+    /** Parameters of the Ipopt optimization problem**/
     yarp::os::Property ipopt_par;
-
-    /** Input image**/
-    yarp::sig::ImageOf<yarp::sig::PixelRgb> *imgIn;
 
     /************************************************************************/
     bool attach(yarp::os::RpcServer &source);

--- a/include/superqVisualization.h
+++ b/include/superqVisualization.h
@@ -36,23 +36,25 @@
 class SuperqVisualization : public yarp::os::RateThread
 {
 protected:
-    // Output image
+    /**Input image port **/
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > portImgIn;
+    /**Output image port *   */
     yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > portImgOut;
 
     // Parameters for visualization
-	/** R value for visualization **/
+    /** R value for visualization **/
     int r;
-	/** Green value for visualization **/
-	int g;
-	/** Blue value for visualization **/
-	int b;
-	/** Time for visualization**/
+    /** Green value for visualization **/
+    int g;
+    /** Blue value for visualization **/
+    int b;
+    /** Time for visualization**/
     double t_vis;
     /** Number of points used for visualization**/
     int vis_points;
-	/** Number of visualization step**/
+    /** Number of visualization step**/
     int vis_step;
-	/** String used for deciding what to plot: "points" or "superq"**/
+    /** String used for deciding what to plot: "points" or "superq"**/
     std::string what_to_plot;
 
     yarp::sig::Vector point,point1;
@@ -60,10 +62,10 @@ protected:
     std::deque<int> Color;
 
     // Variables for gaze
-	/** Eye camera selected **/
+    /** Eye camera selected **/
     std::string eye;
     yarp::sig::Matrix R,H,K;
-	/** Gaze Control interface **/
+    /** Gaze Control interface **/
     yarp::dev::IGazeControl *igaze;
 
     yarp::os::Mutex mutex;
@@ -78,12 +80,12 @@ public:
     std::deque<yarp::sig::Vector> &points;
 
     /** Input image */
-    yarp::sig::ImageOf<yarp::sig::PixelRgb> *&imgIn;
+    yarp::sig::ImageOf<yarp::sig::PixelRgb> *imgIn;
 
     /***********************************************************************/
-    SuperqVisualization(int rate, const std::string &_eye, const std::string &_what_to_plot, yarp::sig::Vector &x, yarp::sig::Vector &x_filtered,
+    SuperqVisualization(int rate, const std::string &_eye, const std::string &_what_to_plot, yarp::sig::Vector &_x, yarp::sig::Vector &_x_filtered,
                         std::deque<int> &_Color, yarp::dev::IGazeControl *_igaze, const yarp::sig::Matrix _K, std::deque<yarp::sig::Vector> &_points,
-                        const int &_vis_points, const int &_vis_step, yarp::sig::ImageOf<yarp::sig::PixelRgb> *&imgIn);
+                        const int &_vis_points, const int &_vis_step);
 
     /** Show point cloud on the image
     * @return true
@@ -112,6 +114,10 @@ public:
     /** Run function of RateThread */
     /***********************************************************************/
     virtual void run();
+
+    /** Interrupt ports functionalities */
+    /***********************************************************************/
+    void interruptPorts();
 
     /** Release function of RateThread */
     /***********************************************************************/

--- a/src/superqComputation.cpp
+++ b/src/superqComputation.cpp
@@ -65,9 +65,9 @@ vector<int>  SpatialDensityFilter::filter(const cv::Mat &data,const double radiu
 }
 
 /***********************************************************************/
-SuperqComputation::SuperqComputation(Mutex &_mutex_shared, int _rate, bool _filter_points, bool _filter_superq, bool _fixed_window,deque<yarp::sig::Vector> &_points, ImageOf<PixelRgb> *_imgIn, string _tag_file, double _threshold_median,
+SuperqComputation::SuperqComputation(Mutex &_mutex_shared, int _rate, bool _filter_points, bool _filter_superq, bool _fixed_window,deque<yarp::sig::Vector> &_points, string _tag_file, double _threshold_median,
                                 const Property &_filter_points_par, Vector &_x, Vector &_x_filtered, const Property &_filter_superq_par, const Property &_ipopt_par, const string &_homeContextPath, bool _save_points, ResourceFinder *_rf):
-                                mutex_shared(_mutex_shared), filter_points(_filter_points), filter_superq(_filter_superq), fixed_window( _fixed_window),tag_file(_tag_file),  threshold_median(_threshold_median), save_points(_save_points), imgIn(_imgIn),
+                                mutex_shared(_mutex_shared), filter_points(_filter_points), filter_superq(_filter_superq), fixed_window( _fixed_window),tag_file(_tag_file),  threshold_median(_threshold_median), save_points(_save_points),
                                 filter_points_par(_filter_points_par),filter_superq_par(_filter_superq_par),ipopt_par(_ipopt_par), Thread(), homeContextPath(_homeContextPath), x(_x), x_filtered(_x_filtered), points(_points), rf(_rf)
 {
 }

--- a/src/superqVisualization.cpp
+++ b/src/superqVisualization.cpp
@@ -28,9 +28,9 @@ using namespace yarp::math;
 /***********************************************************************/
 SuperqVisualization::SuperqVisualization(int _rate,const string &_eye, const string &_what_to_plot, Vector &_x, Vector &_x_filtered,
                                          deque<int> &_Color,IGazeControl *_igaze, const Matrix _K, deque<Vector> &_points,
-                                         const int &_vis_points, const int &_vis_step, ImageOf<PixelRgb> *&_imgIn):
+                                         const int &_vis_points, const int &_vis_step):
                                          RateThread(_rate), eye(_eye), what_to_plot(_what_to_plot), Color(_Color), igaze(_igaze), K(_K),
-                                         vis_points(_vis_points), vis_step(_vis_step), superq(_x), superq_filtered(_x_filtered), points(_points), imgIn(_imgIn)
+                                         vis_points(_vis_points), vis_step(_vis_step), superq(_x), superq_filtered(_x_filtered), points(_points)
 {
 
 }
@@ -179,6 +179,7 @@ bool SuperqVisualization::threadInit()
 {
     yInfo()<<"[SuperqVisualization]: Thread initing ... ";
     
+    portImgIn.open("/superquadric-model/img:i");
     portImgOut.open("/superquadric-model/img:o");
 
     R.resize(4,4);
@@ -194,17 +195,30 @@ bool SuperqVisualization::threadInit()
 void SuperqVisualization::run()
 {
     double t0=Time::now();
-    if (what_to_plot=="superq" && imgIn!=NULL)
-        showSuperq(superq_filtered);
-    else if (what_to_plot=="points" && points.size()>0)
-        showPoints();    
+    if (imgIn=portImgIn.read())
+    {
+        if (what_to_plot=="superq")
+            showSuperq(superq_filtered);
+        else if ((what_to_plot=="points") && (points.size()>0))
+            showPoints();    
+    }
     t_vis=Time::now()-t0;
+}
+
+/**********************************************************************/
+void SuperqVisualization::interruptPorts()
+{
+    portImgIn.interrupt();
+    portImgOut.interrupt();
 }
 
 /**********************************************************************/
 void SuperqVisualization:: threadRelease()
 {
     yInfo()<<"[SuperVisualization]: Thread releasing ... ";
+
+    if (!portImgIn.isClosed())
+        portImgIn.close();
 
     if (!portImgOut.isClosed())
         portImgOut.close();


### PR DESCRIPTION
### Problem
We aim to fix the opening of `/.../img:o` port. We realized that the port gets open only when the first image is received by the port `/.../img:i` during configuration.

What happens at the user level is that it is not clear that 2 subsequent connections are required from within the yarpmanager, plus the timing of the second connection is not deterministic, unfortunately.

The handling of `/.../img:i` is moved inside the visualization thread that is the only piece of code using it. As a consequence, we fix also possible race conditions that might be caused by reading images in the updateModule and consuming those images in the run (there is no mutex).

### Tests
Tests are successful as @claudiofantacci did them extensively.